### PR TITLE
enhance test

### DIFF
--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ from model import process_addresses
 
 def assert_list_of_str(obj: Dict[str, Any], key: str) -> None:
     simple_assert(obj, 'Other', list)
-    a_list = obj.get(key)
+    a_list: List[Any] = obj.get(key)
     for element in a_list:
         found_type = type(element)
         error_message = f'`{key}` must be {List[str]}, but got {List[found_type]}'

--- a/test.py
+++ b/test.py
@@ -1,28 +1,41 @@
-from typing import Dict, List, Union
+from typing import Any, Dict, List
 
 import json
 
 from model import process_addresses
 
 
+def assert_list_of_str(obj: Dict[str, Any], key: str) -> None:
+    simple_assert(obj, 'Other', list)
+    a_list = obj.get(key)
+    for element in a_list:
+        found_type = type(element)
+        error_message = f'`{key}` must be {List[str]}, but got {List[found_type]}'
+        assert isinstance(element, str), error_message
+
+def simple_assert(obj: Dict[str, Any], key: str, expected_type: type) -> None:
+    value = obj.get(key)
+    error_message = f'`{key}` must be {expected_type}, but got {type(value)}'
+    assert isinstance(value, expected_type), error_message
+
 def main() -> None:
     with open("sample.json", "r") as f:
-        sample: list = json.load(f);
+        sample: List[Dict[str, Any]] = json.load(f);
 
     sample = sample[:10];
-    output: list = process_addresses(sample);
+    output = process_addresses(sample);
 
-    # fields and type checkint
+    # fields and type checking
     for idx, item in enumerate(output):
         assert len(set(item.keys()) - {
             "id", "HouseNumber", "PremiseName", "Moo", "SubStreetName",
             "StreetName", "SubDistrict", "District", "Province", "PostalCode",
             "Other"
         }) == 0, f"Invalid keys: {list(item.keys())} on index {idx}"
-        assert isinstance(item["id"], int), f"`id` field must be int but got {type(item['id'])}";
-        assert isinstance(item["PostalCode"], str), f"`id` field must be str but got {type(item['PostalCode'])}";
-        assert isinstance(item["Moo"], str), f"`id` field must be str but got {type(item['Moo'])}";
-        assert isinstance(item["Other"], list), f"`Other` field must be List[str] but got {type(item['Other'])}";
+        simple_assert(item, 'id', int)
+        simple_assert(item, 'PostalCode', str)
+        simple_assert(item, 'Moo', str)
+        assert_list_of_str(item, 'Other')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are improvements required:
1. Error messages were incorrect; `id` was throwing for `PostalCode` and `Moo`.
2. Elements in `Other` weren't checked to be `str`.